### PR TITLE
리듀서 쪼개기 (spliting reducer)

### DIFF
--- a/prepare/front/components/AppLayout.js
+++ b/prepare/front/components/AppLayout.js
@@ -11,7 +11,7 @@ import { useSelector } from "react-redux"; // npm install react-redux
 
 // prepare/front/pages/에서 index.js, profile.js, signup.js에 공통으로 사용할 layout
 const AppLayout = ({ children }) => {
-  const isLoggedIn = useSelector((state) => state.user.isLoggedIn);
+  const { isLoggedIn } = useSelector((state) => state.user);
   // return 분분이 Virtual DOM
   // 반응형 그리드 xs: 모바일, sm: 태블릿, md: 작은 데스크탑
   return (

--- a/prepare/front/components/LoginForm.js
+++ b/prepare/front/components/LoginForm.js
@@ -2,11 +2,10 @@ import React, { useCallback } from "react";
 import { Button, Form, Input } from "antd";
 import Link from "next/link";
 import styled from "styled-components"; // 태그 안에 객체 생성 뒤 style을 설정하면 렌더링 시 새로운 객체로 인식한다 때문에 styled-components 사용
-import PropTypes from "prop-types";
 //* customHook 적용하기
 import useInput from "../hooks/useInput"; // 패턴이 비슷한데 조금씩 다른 것들 커스텀 훅으로 처리할 수 있다
 import { useDispatch } from "react-redux"; // useDispatch()
-import { loginAction } from "../reducers";
+import { loginAction } from "../reducers/user";
 
 const LoginForm = () => {
   const dispatch = useDispatch();

--- a/prepare/front/components/UserProfile.js
+++ b/prepare/front/components/UserProfile.js
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import { Avatar, Button, Card } from "antd";
 // react-redux
 import { useDispatch } from "react-redux";
-import { logoutAction } from "../reducers";
+import { logoutAction } from "../reducers/user";
 
 const UserProfile = () => {
   const dispatch = useDispatch();

--- a/prepare/front/reducers/index.js
+++ b/prepare/front/reducers/index.js
@@ -1,63 +1,28 @@
-import { HYDRATE } from "next-redux-wrapper";
-
-// reducer
-const initialState = {
-  user: {
-    isLoggedIn: false,
-    user: null,
-    signUpData: {},
-    loginData: {},
-  },
-  post: {
-    main: [],
-  },
-};
+import { HYDRATE } from "next-redux-wrapper"; // SSR(Server Side Rendering)을 위함
+import { combineReducers } from "redux"; // combineReducers은 reducer 함수를 합쳐주는 역할
+// spliting reducer
+import user from "./user";
+import post from "./post";
 
 // async action creator(비동기) / redux-saga
 
-// action creactor
-export const loginAction = (data) => {
-  return {
-    type: "LOG_IN",
-    data,
-  };
-};
-export const logoutAction = () => {
-  return {
-    type: "LOG_OUT",
-  };
-};
-
 // (이전상태, 액션) >> 다음 상태
-const rootReducer = (state = initialState, action) => {
-  switch (action.type) {
-    case HYDRATE:
-      console.log("HYDRATE", action);
-      return {
-        ...state,
-        ...action.payload,
-      };
-    case "LOG_IN":
-      return {
-        ...state,
-        user: {
-          ...state.user, // 바꾸지 않을 데이터는 참조관계 유지
-          isLoggedIn: true,
-          user: action.data,
-        },
-      };
-    case "LOG_OUT":
-      return {
-        ...state,
-        user: {
-          ...state.user,
-          isLoggedIn: false,
-          user: null,
-        },
-      };
-    default:
-      return state;
-  }
-};
+const rootReducer = combineReducers({
+  // HYDRATE를 위해 index reducer를 추가 (SSR을 위해 추가함)
+  index: (state = {}, action) => {
+    switch (action.type) {
+      case HYDRATE:
+        console.log("HYDRATE", action);
+        return {
+          ...state,
+          ...action.payload,
+        };
+      default:
+        return state;
+    }
+  },
+  user,
+  post,
+});
 
 export default rootReducer;

--- a/prepare/front/reducers/post.js
+++ b/prepare/front/reducers/post.js
@@ -1,0 +1,12 @@
+export const initialState = {
+  mainPosts: [],
+};
+
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/prepare/front/reducers/user.js
+++ b/prepare/front/reducers/user.js
@@ -1,0 +1,40 @@
+export const initialState = {
+  isLoggedIn: false,
+  user: null,
+  signUpData: {},
+  loginData: {},
+};
+
+// action creactor
+export const loginAction = (data) => {
+  return {
+    type: "LOG_IN",
+    data,
+  };
+};
+export const logoutAction = () => {
+  return {
+    type: "LOG_OUT",
+  };
+};
+
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case "LOG_IN":
+      return {
+        ...state, // 바꾸지 않을 데이터는 참조관계 유지
+        isLoggedIn: true,
+        user: action.data,
+      };
+    case "LOG_OUT":
+      return {
+        ...state,
+        isLoggedIn: false,
+        user: null,
+      };
+    default:
+      return state;
+  }
+};
+
+export default reducer;


### PR DESCRIPTION
- initialState의 user와 post 객체 기준으로 user.js && post.js 파일 생성
- index.js에서 combineReducers()로 user의 reducer와 post의 reducer를 합친다.
- SSR을 위해 index.js 안에 HYDRATE를 next-redux-wrapper 안에서 import 해온 후 
rootReducer에 index reducer를 추가해준다.
- 로그인 폼이나 user 프로필 파일에서 reducer 경로를 다시 설정 해준다

** switch문을 작성 할때, action.type 유의해서 작성할 것 **
"action.type을 action이라고만 적는 실수를 범함, 그래서 로그인 로그아웃 시 isLoggedIn을 못 받아왔는지 작동이 되지 않았었음"